### PR TITLE
fix: 替换裸 location.href / location.replace / location.assign

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -1357,6 +1357,9 @@ async function handleRequest(request) {
       if (contentType && (contentType.includes("html") || contentType.includes("javascript"))) {
         bd = bd.replaceAll("window.location", "window." + replaceUrlObj);
         bd = bd.replaceAll("document.location", "document." + replaceUrlObj);
+        bd = bd.replaceAll("location.href", replaceUrlObj + ".href");
+        bd = bd.replaceAll("location.replace(", replaceUrlObj + ".replace(");
+        bd = bd.replaceAll("location.assign(", replaceUrlObj + ".assign(");
       }
 
 


### PR DESCRIPTION
部分网站使用不带 window. 或 document. 前缀的裸 location 进行页面跳转， 导致相对路径被解析到代理源地址而非被代理的目标网址。例如manhuagui.com的章节导航使用 location.href = "/comic/..." 直接跳转，绕过了代理。
新增对 location.href、location.replace(、location.assign( 的字符串替换， 使其也经过 ProxyLocation 处理。